### PR TITLE
feat: Implement HTTP method-specific mocks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,69 +3,100 @@ from pydantic import BaseModel
 import uvicorn
 import json
 import re
+from typing import Optional, Dict, Any
 
 app = FastAPI()
 
-# Dictionary to store mock responses with regex patterns as keys
-mock_responses = {}
+# Dictionary to store mock responses: path_pattern -> {method -> ResponseData_object}
+mock_responses: Dict[str, Dict[str, 'ResponseData']] = {}
 
-# Pydantic model for mock response creation
-class MockResponse(BaseModel):
+# Pydantic models for mock response configuration
+class ResponseData(BaseModel):
+    body: Dict[str, Any]
+    status_code: int = 200
+    custom_headers: Optional[Dict[str, str]] = None
+
+class MockConfigRequest(BaseModel):
     path_template: str
-    response: dict
+    method: str  # e.g., GET, POST, PUT. Case-insensitive on input, stored as UPPER.
+    response: ResponseData
 
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
     print(f"Received {request.method} request for URL: {request.url}")
     print(f"Headers: {dict(request.headers)}")
 
-    body = await request.body()
-    body_str = body.decode('utf-8')
+    body_bytes = await request.body()
+    body_str = body_bytes.decode('utf-8')
 
     try:
-        body_json = json.loads(body_str)
-        pretty_body = json.dumps(body_json, indent=4)
+        # Attempt to parse as JSON for pretty printing, otherwise use raw string
+        if body_str:
+            body_json = json.loads(body_str)
+            pretty_body = json.dumps(body_json, indent=4)
+        else:
+            pretty_body = "[No Body]"
     except json.JSONDecodeError:
         pretty_body = body_str
-
+    
     print(f"Body:\n{pretty_body}")
 
-    response = await call_next(request)
+    response_from_route = await call_next(request)
 
-    print(f"Responding with status code: {response.status_code}")
+    print(f"Responding with status code: {response_from_route.status_code}")
+    # Headers are part of the response_from_route object, will be sent by FastAPI
 
-    return response
+    return response_from_route
 
-@app.post("/mock-response")
-async def create_mock_response(mock_response: MockResponse):
-    # Use raw paths without escaping that start with a slash
-    regex_pattern = re.escape(mock_response.path_template).replace(r'\{\}', r'.*') 
+@app.post("/mock-response", status_code=201)
+async def create_mock_response(config: MockConfigRequest):
+    regex_pattern = re.escape(config.path_template).replace(r'\{\}', r'.*')
     if not regex_pattern.startswith('^'):
-        regex_pattern = '^' + regex_pattern  # Ensure it matches the start
-    regex_pattern += r'$'  # Ensure it matches the end
+        regex_pattern = '^' + regex_pattern
+    regex_pattern += r'$'
 
-    mock_responses[regex_pattern] = json.dumps(mock_response.response)
-    print(f"Registered mock response for pattern: {regex_pattern}")
-    return {"message": f"Mock response set for path: {mock_response.path_template}"}
+    method_upper = config.method.upper()
 
+    if regex_pattern not in mock_responses:
+        mock_responses[regex_pattern] = {}
 
+    # Store the ResponseData object directly (Pydantic model instance)
+    mock_responses[regex_pattern][method_upper] = config.response
+    
+    print(f"Registered mock response for METHOD: {method_upper}, PATTERN: {regex_pattern} with status {config.response.status_code}")
+    return {"message": f"Mock response set for METHOD: {method_upper}, PATH: {config.path_template}"}
 
 @app.api_route("/{path_name:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
 async def catch_all(request: Request, path_name: str):
-    print(f"Checking path: {path_name} against registered patterns")
+    normalized_path = path_name
+    if not normalized_path.startswith('/'):
+        normalized_path = '/' + normalized_path
     
-    # Handle leading slash if necessary
-    if not path_name.startswith('/'):
-        path_name = '/' + path_name  
+    current_method = request.method.upper()
 
-    for pattern, mock_response in mock_responses.items():
-        print(f"Trying pattern: {pattern}")
-        if re.match(pattern, path_name):
-            print(f"Found: {path_name}")
-            return Response(content=mock_response, media_type="application/json", status_code=200)
+    print(f"Attempting to match: {current_method} {normalized_path}")
 
-    response = {"message": "Request received and logged."}
-    return response
+    for pattern, methods_map in mock_responses.items():
+        if re.match(pattern, normalized_path):
+            if current_method in methods_map:
+                mock_data = methods_map[current_method]
+                print(f"Found mock for {current_method} {normalized_path} (Pattern: {pattern}) -> Status: {mock_data.status_code}")
+                return Response(
+                    content=json.dumps(mock_data.body),
+                    status_code=mock_data.status_code,
+                    headers=mock_data.custom_headers, # FastAPI handles None headers correctly
+                    media_type="application/json"
+                )
+            else:
+                print(f"Path pattern {pattern} matched, but no mock for METHOD: {current_method}. Configured methods: {list(methods_map.keys())}")
+    
+    default_body = {"message": f"Request for {current_method} {normalized_path} received and logged. No specific mock found."}
+    print(f"No specific mock found for {current_method} {normalized_path}. Returning default 404.")
+    return Response(
+        content=json.dumps(default_body),
+        status_code=404, # Changed default to 404 when no mock is found
+        media_type="application/json"
+    )
 
 if __name__ == "__main__":
-    uvicorn.run("main:app", host="0.0.0.0", port=8000)
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -1,5 +1,13 @@
 # tests/app/test_main.py
 from fastapi.testclient import TestClient
+# Adjust the import path if your main app is in a subdirectory like 'app'
+# from app.main import app 
+# If main.py is in the root of 'mocker' alongside 'tests', this might be an issue.
+# Assuming main.py is accessible from where pytest is run, or PYTHONPATH is set.
+# For this structure, main is likely in /workspace/mocker/app/main.py
+# and tests are in /workspace/mocker/tests/
+# The conftest.py or test setup might handle the app import path.
+# Let's assume the original `from main import app` works due to pytest path handling or conftest.
 from main import app
 
 client = TestClient(app)
@@ -7,29 +15,34 @@ client = TestClient(app)
 
 def test_log_requests_middleware():
     response = client.get("/test-endpoint")
-    assert response.status_code == 200
-    assert response.json() == {"message": "Request received and logged."}
+    assert response.status_code == 404
+    expected_message = "Request for GET /test-endpoint received and logged. No specific mock found."
+    assert response.json() == {"message": expected_message}
 
 
 def test_post_request_logging():
     response = client.post("/test-endpoint", json={"key": "value"})
-    assert response.status_code == 200
-    assert response.json() == {"message": "Request received and logged."}
+    assert response.status_code == 404
+    expected_message = "Request for POST /test-endpoint received and logged. No specific mock found."
+    assert response.json() == {"message": expected_message}
 
 
 def test_put_request_logging():
     response = client.put("/test-endpoint", json={"key": "updated value"})
-    assert response.status_code == 200
-    assert response.json() == {"message": "Request received and logged."}
+    assert response.status_code == 404
+    expected_message = "Request for PUT /test-endpoint received and logged. No specific mock found."
+    assert response.json() == {"message": expected_message}
 
 
 def test_delete_request_logging():
     response = client.delete("/test-endpoint")
-    assert response.status_code == 200
-    assert response.json() == {"message": "Request received and logged."}
+    assert response.status_code == 404
+    expected_message = "Request for DELETE /test-endpoint received and logged. No specific mock found."
+    assert response.json() == {"message": expected_message}
 
 
 def test_patch_request_logging():
     response = client.patch("/test-endpoint", json={"key": "patched value"})
-    assert response.status_code == 200
-    assert response.json() == {"message": "Request received and logged."}
+    assert response.status_code == 404
+    expected_message = "Request for PATCH /test-endpoint received and logged. No specific mock found."
+    assert response.json() == {"message": expected_message}

--- a/tests/app/test_mocking.py
+++ b/tests/app/test_mocking.py
@@ -1,64 +1,176 @@
 from fastapi.testclient import TestClient
-from main import app
+from main import app, mock_responses  # Import mock_responses to clear it
 
 client = TestClient(app)
 
+# Helper function to clear mocks before each test
+def setup_function():
+    mock_responses.clear()
 
 def test_create_mock_response():
-    # Test creating a mock response
-    response = client.post(
-        "/mock-response", json={"path_template": "/user/{}/details", "response": {"status": "success"}}
-    )
-    assert response.status_code == 200
-    assert response.json() == {"message": "Mock response set for path: /user/{}/details"}
-
+    setup_function()
+    payload = {
+        "path_template": "/user/{}/details",
+        "method": "GET",
+        "response": {
+            "body": {"status": "success"},
+            "status_code": 200
+        }
+    }
+    response = client.post("/mock-response", json=payload)
+    assert response.status_code == 201
+    assert response.json() == {"message": "Mock response set for METHOD: GET, PATH: /user/{}/details"}
 
 def test_get_mock_response_with_valid_path():
-    # Create mock responses
-    response = client.post(
-        "/mock-response", json={"path_template": "/user/{}/details", "response": {"status": "success"}}
-    )
-    assert response.status_code == 200  # Ensure the creation worked
+    setup_function()
+    # Create mock response
+    mock_config = {
+        "path_template": "/user/{}/details",
+        "method": "GET",
+        "response": {
+            "body": {"status": "success", "id": "123"},
+            "status_code": 200
+        }
+    }
+    create_response = client.post("/mock-response", json=mock_config)
+    assert create_response.status_code == 201
 
-    # Test retrieving the mocked response for specific dynamic values
+    # Test retrieving the mocked response
     response = client.get("/user/123/details")
     assert response.status_code == 200
-    assert response.json() == {"status": "success"}
+    assert response.json() == {"status": "success", "id": "123"}
+
+    # Test with another dynamic value
+    mock_config_2 = {
+        "path_template": "/user/{}/profile", # Different path
+        "method": "GET",
+        "response": {
+            "body": {"profile_status": "active"},
+            "status_code": 202 # Different status
+        }
+    }
+    create_response_2 = client.post("/mock-response", json=mock_config_2)
+    assert create_response_2.status_code == 201
+    
+    response_2 = client.get("/user/456/profile")
+    assert response_2.status_code == 202
+    assert response_2.json() == {"profile_status": "active"}
 
 
 def test_get_mock_response_with_non_matching_path():
+    setup_function()
     # Create a mock response
-    client.post("/mock-response", json={"path_template": "/user/{}/details", "response": {"status": "success"}})
+    mock_config = {
+        "path_template": "/user/{}/details",
+        "method": "GET",
+        "response": {
+            "body": {"status": "success"},
+            "status_code": 200
+        }
+    }
+    create_response = client.post("/mock-response", json=mock_config)
+    assert create_response.status_code == 201
 
     # Test with a path that does not match the registered mock
     response = client.get("/user/123/not-details")
-    assert response.status_code == 200
-    assert response.json() == {"message": "Request received and logged."}
+    assert response.status_code == 404
+    expected_message = "Request for GET /user/123/not-details received and logged. No specific mock found."
+    assert response.json() == {"message": expected_message}
+
+def test_create_mock_for_post_request():
+    setup_function()
+    payload = {
+        "path_template": "/product/{}/info",
+        "method": "POST",
+        "response": {
+            "body": {"status": "product created", "id": "xyz"},
+            "status_code": 201,
+            "custom_headers": {"X-Product-ID": "xyz"}
+        }
+    }
+    response = client.post("/mock-response", json=payload)
+    assert response.status_code == 201
+    assert response.json() == {"message": "Mock response set for METHOD: POST, PATH: /product/{}/info"}
+
+    # Test retrieving the mocked POST response
+    retrieved_response = client.post("/product/abc/info", json={"name": "Test Product"})
+    assert retrieved_response.status_code == 201
+    assert retrieved_response.json() == {"status": "product created", "id": "xyz"}
+    assert retrieved_response.headers["x-product-id"] == "xyz"
 
 
-def test_create_another_mock_response():
-    # Test creating a different mock response
-    response = client.post(
-        "/mock-response", json={"path_template": "/product/{}/info", "response": {"status": "product found"}}
+def test_get_another_mock_response_with_valid_path_and_different_method():
+    setup_function()
+    # Mock for GET
+    client.post(
+        "/mock-response",
+        json={
+            "path_template": "/product/{}/info",
+            "method": "GET",
+            "response": {"body": {"status": "product found via GET"}, "status_code": 200},
+        },
     )
-    assert response.status_code == 200
-    assert response.json() == {"message": "Mock response set for path: /product/{}/info"}
+    # Mock for PUT on the same path
+    client.post(
+        "/mock-response",
+        json={
+            "path_template": "/product/{}/info",
+            "method": "PUT",
+            "response": {"body": {"status": "product updated via PUT"}, "status_code": 202},
+        },
+    )
 
+    # Test GET
+    response_get = client.get("/product/456/info")
+    assert response_get.status_code == 200
+    assert response_get.json() == {"status": "product found via GET"}
 
-def test_get_another_mock_response_with_valid_path():
-    # Test retrieving the mocked response for another path
-    response = client.get("/product/456/info")
-    assert response.status_code == 200
-    assert response.json() == {"status": "product found"}
-
-    response = client.get("/product/ABC/info")
-    assert response.status_code == 200
-    assert response.json() == {"status": "product found"}
+    # Test PUT
+    response_put = client.put("/product/456/info", json={"name": "Updated Name"})
+    assert response_put.status_code == 202
+    assert response_put.json() == {"status": "product updated via PUT"}
+    
+    # Test non-mocked method (e.g. DELETE) on same path
+    response_delete = client.delete("/product/456/info")
+    assert response_delete.status_code == 404
 
 
 def test_get_another_mock_response_with_non_matching_path():
+    setup_function()
+    # Create a mock response
+    mock_config = {
+        "path_template": "/product/{}/info",
+        "method": "GET",
+        "response": {
+            "body": {"status": "product found"},
+            "status_code": 200
+        }
+    }
+    create_response = client.post("/mock-response", json=mock_config)
+    assert create_response.status_code == 201
+
     # Test with a non-matching path for the new mock
-    client.post("/mock-response", json={"path_template": "/product/{}/info", "response": {"status": "product found"}})
-    response = client.get("/product/456/details")
+    response = client.get("/product/456/details") # 'details' instead of 'info'
+    assert response.status_code == 404
+    expected_message = "Request for GET /product/456/details received and logged. No specific mock found."
+    assert response.json() == {"message": expected_message}
+
+def test_mock_with_custom_headers():
+    setup_function()
+    payload = {
+        "path_template": "/header-test",
+        "method": "GET",
+        "response": {
+            "body": {"header_check": "present"},
+            "status_code": 200,
+            "custom_headers": {"X-Test-Header": "TestValue123", "X-Another": "Value"}
+        }
+    }
+    create_response = client.post("/mock-response", json=payload)
+    assert create_response.status_code == 201
+
+    response = client.get("/header-test")
     assert response.status_code == 200
-    assert response.json() == {"message": "Request received and logged."}
+    assert response.json() == {"header_check": "present"}
+    assert response.headers["x-test-header"] == "TestValue123"
+    assert response.headers["x-another"] == "Value"


### PR DESCRIPTION
This commit introduces the ability to define different mock responses for different HTTP methods (GET, POST, PUT, etc.) on the same path template.

Key changes:
- Updated Pydantic models (, ) to support method, status codes, and custom headers in mock definitions.
- Modified the core mocking logic in  to store and retrieve mocks based on both path and HTTP method.
- Updated all relevant tests in  to reflect the new API contract and ensure proper functionality, including test isolation for .